### PR TITLE
specify minimum Python version to be 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,14 @@ setup(
     name="hiresprv",
     version="1.0.0",
     author="Mihseh Kong, John Good, BJ Fulton",
+    classifiers=[
+        'Intended Audience :: Science/Research',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Scientific/Engineering :: Astronomy'],
     packages=find_packages(),
     data_files=[],
     install_requires=reqs,
+    python_requires='>= 3.6',
     include_package_data=False
 )


### PR DESCRIPTION
Add Python version information to `setup.py` to specify Python 3.6 as the minimum version (in consultation with @bjfultn). 

The PR comes from my fork because I don't have write access to the repository.
